### PR TITLE
Convert ci-pipeline-poll-scm to GitHub Actions

### DIFF
--- a/.github/workflows/ci-pipeline-poll-scm.yml
+++ b/.github/workflows/ci-pipeline-poll-scm.yml
@@ -6,7 +6,7 @@ on:
   schedule:
   - cron: 00 00 * * *
 env:
-  #MONGO_URI: mongodb+srv://supercluster.d83jj.mongodb.net/superData
+  MONGO_URI: mongodb+srv://supercluster.d83jj.mongodb.net/superData
   MONGO_USERNAME: superuser
   MONGO_PASSWORD: "${{ secrets.mongo_db_password }}"
 jobs:
@@ -105,20 +105,13 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4.1.0
-#     # This item has no matching transformer
-#     - catchError:
-#       - key: buildResult
-#         value:
-#           isLiteral: true
-#           value: SUCCESS
-#       - key: message
-#         value:
-#           isLiteral: true
-#           value: Oops! it will be fixed in future releases
-#       - key: stageResult
-#         value:
-#           isLiteral: true
-#           value: UNSTABLE
+    - name: Install dependencies
+      run: npm install --no-audit
+      shell: bash
+    - name: Check Code Coverage
+      continue-on-error: true
+      run: npm run coverage
+      shell: bash
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4.1.0
       with:


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://139.84.149.83:8080/job/ci-pipeline-poll-scm/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ci-pipeline-poll-scm
- [ ] Ensure secret is available: `${{ secrets.mongo_db_password }}`
- [ ] Ensure build tool is available: `nodejs`