### PR TITLE
Convert ci-pipeline-poll-scm to GitHub Actions

### DIFF
--- a/.github/workflows/ci-pipeline-poll-scm.yml
+++ b/.github/workflows/ci-pipeline-poll-scm.yml
@@ -126,16 +126,19 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4.1.0
-#     # This item has no matching transformer
-#     - withDockerRegistry:
-#       - key: credentialsId
-#         value:
-#           isLiteral: true
-#           value: docker-hub-credentials
-#       - key: url
-#         value:
-#           isLiteral: true
-#           value: ''
+    - name: Build Docker image
+      run: docker build -t ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}:${{ github.sha }} .
+      shell: bash
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: "${{ vars.DOCKERHUB_USERNAME }}"
+        password: "${{ secrets.DOCKERHUB_PASSWORD }}"
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        push: true
+        tags: "${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME  }}:${{ github.sha }}"
   Trivy_Vulnerability_Scanner:
     name: Trivy Vulnerability Scanner
     runs-on:


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://139.84.149.83:8080/job/ci-pipeline-poll-scm/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ci-pipeline-poll-scm
- [x] Ensure secret is available: `${{ secrets.mongo_db_password }}`
- [x] Ensure build tool is available: `nodejs`